### PR TITLE
Feature/recursive transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 - BaseParentField to be extended by ACF fields that have sub_fields (enable recursive build and transform)
 - ACF Layout field (usage of BaseSection is deprecated)
+- Full support for builder pattern on BaseField for common configurations
 
 ### Changed
 
 - Add ACF registration parameters to BaseField constructor (passing those via the build method is deprecated)
 - Namespace of this package 
+- FieldGroup such that it uses a wrapper group internally to wrap its sub fields
 
 ## [v2.2.0] - 17.02.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Add ACF registration parameters to BaseField constructor (passing those via the build method is deprecated)
+- Namespace of this package
 
 ## [v2.2.0] - 17.02.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - Add ACF registration parameters to BaseField constructor (passing those via the build method is deprecated)
-- Namespace of this package
+- Namespace of this package 
 
 ## [v2.2.0] - 17.02.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [unreleased]
+
+### Added
+
+- BaseParentField to be extended by ACF fields that have sub_fields (enable recursive build and transform)
+- ACF Layout field (usage of BaseSection is deprecated)
+
+### Changed
+
+- Add ACF registration parameters to BaseField constructor (passing those via the build method is deprecated)
+
 ## [v2.2.0] - 17.02.2022
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     },
     "autoload": {
         "psr-4": {
-            "Towa\\Acf\\": "src/"
+            "DigitOne\\Acf\\": "src/"
         }
     },
     "require": {
-        "illuminate/support": "^9.10"
+        "illuminate/support": "^8.0.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-    "name": "towa/towa-acf-fields",
+    "name": "digit-one-dev/d1-acf-fields",
     "license": "MIT",
     "description": "ACF Fields Developer SDK",
     "authors": [
         {
-            "name": "David Seidl",
-            "email": "david.seidl@towa.at"
+            "name": "Philipp Scambor",
+            "email": "philipp.scambor@digit-one.com"
         },
         {
-            "name": "SahinU88",
-            "email": "sahin.ucar@towa.at"
+            "name": "Islam Mechtijev",
+            "email": "islam.mechtijev@digit-one.com"
         }
     ],
     "require-dev": {
@@ -24,5 +24,8 @@
         "psr-4": {
             "Towa\\Acf\\": "src/"
         }
+    },
+    "require": {
+        "illuminate/support": "^9.10"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,972 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0439d9033a1b72ad63ccf081f73ddee5",
-    "packages": [],
+    "content-hash": "5f99bffe0e3575d0fb1ca8f17fed680a",
+    "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "vimeo/psalm": "^4.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T20:16:43+00:00"
+        },
+        {
+            "name": "illuminate/collections",
+            "version": "v9.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/collections.git",
+                "reference": "5be9f49dc490570515bc5e4180570b6f079fb964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/5be9f49dc490570515bc5e4180570b6f079fb964",
+                "reference": "5be9f49dc490570515bc5e4180570b6f079fb964",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/conditionable": "^9.0",
+                "illuminate/contracts": "^9.0",
+                "illuminate/macroable": "^9.0",
+                "php": "^8.0.2"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Required to use the dump method (^6.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Collections package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-04-27T13:13:22+00:00"
+        },
+        {
+            "name": "illuminate/conditionable",
+            "version": "v9.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/conditionable.git",
+                "reference": "56b4ba1166c264064bf63896f498a2bee320d16a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/56b4ba1166c264064bf63896f498a2bee320d16a",
+                "reference": "56b4ba1166c264064bf63896f498a2bee320d16a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Conditionable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-02-28T16:37:46+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v9.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "8641ad7d4e28f399adef15e4087ae2ddf90dc2cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/8641ad7d4e28f399adef15e4087ae2ddf90dc2cc",
+                "reference": "8641ad7d4e28f399adef15e4087ae2ddf90dc2cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "psr/simple-cache": "^1.0|^2.0|^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-04-22T14:42:13+00:00"
+        },
+        {
+            "name": "illuminate/macroable",
+            "version": "v9.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/macroable.git",
+                "reference": "25a2c6dac2b7541ecbadef952702e84ae15f5354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/25a2c6dac2b7541ecbadef952702e84ae15f5354",
+                "reference": "25a2c6dac2b7541ecbadef952702e84ae15f5354",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Macroable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-02-01T14:44:21+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v9.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "c55e53766798b828791076d1d07198150302ce22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/c55e53766798b828791076d1d07198150302ce22",
+                "reference": "c55e53766798b828791076d1d07198150302ce22",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^2.0",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^9.0",
+                "illuminate/conditionable": "^9.0",
+                "illuminate/contracts": "^9.0",
+                "illuminate/macroable": "^9.0",
+                "nesbot/carbon": "^2.53.1",
+                "php": "^8.0.2",
+                "voku/portable-ascii": "^2.0"
+            },
+            "conflict": {
+                "tightenco/collect": "<5.5.33"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (^9.0).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0.2).",
+                "ramsey/uuid": "Required to use Str::uuid() (^4.2.2).",
+                "symfony/process": "Required to use the composer class (^6.0).",
+                "symfony/var-dumper": "Required to use the dd function (^6.0).",
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-04-25T22:23:46+00:00"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "2.57.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/briannesbitt/Carbon.git",
+                "reference": "4a54375c21eea4811dbd1149fe6b246517554e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4a54375c21eea4811dbd1149fe6b246517554e78",
+                "reference": "4a54375c21eea4811dbd1149fe6b246517554e78",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1.8 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.0 || ^3.0",
+                "doctrine/orm": "^2.7",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "kylekatarnls/multi-tester": "^2.0",
+                "phpmd/phpmd": "^2.9",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.54 || ^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "2.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbon.nesbot.com",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbon.nesbot.com/docs",
+                "issues": "https://github.com/briannesbitt/Carbon/issues",
+                "source": "https://github.com/briannesbitt/Carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-13T18:13:33+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-30T18:21:41+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-13T13:58:33+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v6.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "3d38cf8f8834148c4457681d539bc204de701501"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/3d38cf8f8834148c4457681d539bc204de701501",
+                "reference": "3d38cf8f8834148c4457681d539bc204de701501",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.3|^3.0"
+            },
+            "conflict": {
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/service-contracts": "^1.1.2|^2|^3",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v6.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-22T08:18:02+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "1211df0afa701e45a04253110e959d4af4ef0f07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/1211df0afa701e45a04253110e959d4af4ef0f07",
+                "reference": "1211df0afa701e45a04253110e959d4af4ef0f07",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:53:40+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-ascii/issues",
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-08T17:03:00+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/pcre",
@@ -562,54 +1526,6 @@
                 "source": "https://github.com/php-fig/cache/tree/master"
             },
             "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
-            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1485,89 +2401,6 @@
             "time": "2021-02-19T12:13:01+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-11-30T18:21:41+00:00"
-        },
-        {
             "name": "symfony/polyfill-php73",
             "version": "v1.24.0",
             "source": {
@@ -1645,89 +2478,6 @@
                 }
             ],
             "time": "2021-06-05T21:20:04+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.24.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-09-13T13:58:33+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -2109,5 +2859,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -6,7 +6,6 @@ use DigitOne\Acf\Helper\AcfWpmlHelper;
 
 class BaseField
 {
-    private $key;
     protected $prefix;
     protected $name;
     protected $label;
@@ -19,13 +18,19 @@ class BaseField
         $this->set_prefix($prefix);
         $this->set_name($name);
         $this->set_label($label);
-        $this->set_key($this->prefix . '_' . $this->get_name());
         $this->add_args($args);
 
         if ($is_search_key) {
             $this->add_as_search_key();
         }
+
+        $this->post_construct();
     }
+
+    /**
+     * Method to be extended by subclasses to add their specific logic after construction.
+     */
+    public function post_construct() {}
 
     /**
      * $parameter to override
@@ -58,7 +63,7 @@ class BaseField
      *
      * @return string
      */
-    protected function prefix($prefix)
+    public function prefix($prefix)
     {
         $this->set_prefix($prefix);
 
@@ -70,7 +75,7 @@ class BaseField
      *
      * @return string
      */
-    protected function set_prefix($prefix)
+    public function set_prefix($prefix)
     {
         $this->prefix = $prefix ?? $this->prefix;
     }
@@ -88,7 +93,7 @@ class BaseField
      *
      * @return string
      */
-    protected function name($name)
+    public function name($name)
     {
         $this->set_name($name);
 
@@ -100,7 +105,7 @@ class BaseField
      *
      * @return string
      */
-    protected function set_name($name)
+    public function set_name($name)
     {
         $this->name = $name ?? $this->name;
     }
@@ -112,13 +117,43 @@ class BaseField
     {
         return $this->name;
     }
+
+    /**
+     * @param $instructions
+     *
+     * @return string
+     */
+    public function instructions($instructions)
+    {
+        $this->set_instructions($instructions);
+
+        return $this;
+    }
+
+    /**
+     * @param $instructions
+     *
+     * @return string
+     */
+    public function set_instructions($instructions)
+    {
+        $this->args['instructions'] = $instructions;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_instructions()
+    {
+        return $this->args['instructions'];
+    }
     
     /**
      * @param $label
      *
      * @return string
      */
-    protected function label($label)
+    public function label($label)
     {
         $this->set_label($label);
 
@@ -130,7 +165,7 @@ class BaseField
      *
      * @return string
      */
-    protected function set_label($label)
+    public function set_label($label)
     {
         $this->label = $label ?? $this->label;
     }
@@ -144,33 +179,11 @@ class BaseField
     }
 
     /**
-     * @param $key
-     *
-     * @return string
-     */
-    protected function key($key)
-    {
-        $this->set_key($key);
-
-        return $this;
-    }
-
-    /**
-     * @param $key
-     *
-     * @return string
-     */
-    private function set_key($key)
-    {
-        $this->key = $key;
-    }
-
-    /**
      * @return string
      */
     public function get_key()
     {
-        return $this->key;
+        return $this->prefix . '_' . $this->get_name();
     }
 
     /**
@@ -178,7 +191,7 @@ class BaseField
      *
      * @return string
      */
-    protected function args($args)
+    public function args($args)
     {
         $this->add_args($args);
 

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -16,7 +16,7 @@ class BaseField
 
     public function __construct($prefix = '', $name = null, $label = null, $args = [], $is_search_key = false, )
     {
-        $this->prefix = $prefix;
+        $this->set_prefix($prefix);
         $this->set_name($name);
         $this->set_label($label);
         $this->set_key($this->prefix . '_' . $this->get_name());
@@ -52,6 +52,49 @@ class BaseField
         return $data;
     }
 
+
+    /**
+     * @param $prefix
+     *
+     * @return string
+     */
+    protected function prefix($prefix)
+    {
+        $this->set_prefix($prefix);
+
+        return $this;
+    }
+
+    /**
+     * @param $prefix
+     *
+     * @return string
+     */
+    protected function set_prefix($prefix)
+    {
+        $this->prefix = $prefix ?? $this->prefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_prefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param $name
+     *
+     * @return string
+     */
+    protected function name($name)
+    {
+        $this->set_name($name);
+
+        return $this;
+    }
+
     /**
      * @param $name
      *
@@ -75,7 +118,7 @@ class BaseField
      *
      * @return string
      */
-    protected function with_label($label)
+    protected function label($label)
     {
         $this->set_label($label);
 
@@ -105,6 +148,18 @@ class BaseField
      *
      * @return string
      */
+    protected function key($key)
+    {
+        $this->set_key($key);
+
+        return $this;
+    }
+
+    /**
+     * @param $key
+     *
+     * @return string
+     */
     private function set_key($key)
     {
         $this->key = $key;
@@ -116,6 +171,18 @@ class BaseField
     public function get_key()
     {
         return $this->key;
+    }
+
+    /**
+     * @param $args
+     *
+     * @return string
+     */
+    protected function args($args)
+    {
+        $this->add_args($args);
+
+        return $this;
     }
 
     /**
@@ -159,6 +226,18 @@ class BaseField
     public static function get_search_keys()
     {
         return self::$search_keys;
+    }
+
+    /**
+     * @param $wpml_translation_preference
+     *
+     * @return string
+     */
+    protected function wpml_translation_preference($wpml_translation_preference)
+    {
+        $this->set_wpml_translation_preference($wpml_translation_preference);
+
+        return $this;
     }
 
     /**

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -5,11 +5,17 @@ namespace DigitOne\Acf;
 use DigitOne\Acf\Helper\AcfWpmlHelper;
 use DigitOne\Acf\OptionTraits\Instructions;
 use DigitOne\Acf\OptionTraits\Required;
+use DigitOne\Acf\OptionTraits\DefaultValue;
+use DigitOne\Acf\OptionTraits\ConditionalLogic;
+use DigitOne\Acf\OptionTraits\Wrapper;
 
 class BaseField
 {
     use Instructions;
     use Required;
+    use DefaultValue;
+    use ConditionalLogic;
+    use Wrapper;
 
     protected $prefix;
     protected $name;

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -11,14 +11,16 @@ class BaseField
     protected $name;
     protected $label;
     private static $search_keys;
+    protected $args = [];   
     private $wpml_preference;
 
-    public function __construct($prefix, $name = null, $label = null, $is_search_key = false)
+    public function __construct($prefix = '', $name = null, $label = null, $args = [], $is_search_key = false, )
     {
         $this->prefix = $prefix;
         $this->set_name($name);
         $this->set_label($label);
         $this->set_key($this->prefix . '_' . $this->get_name());
+        $this->add_args($args);
 
         if ($is_search_key) {
             $this->add_as_search_key();
@@ -42,9 +44,13 @@ class BaseField
             'wpml_cf_preferences' => $this->get_wpml_translation_preference(),
         ];
 
-        return array_merge($defaults, $parameter);
+        return array_merge($defaults, $parameter, $this->args);
     }
 
+    public function transform($data)
+    {
+        return $data;
+    }
 
     /**
      * @param $name
@@ -62,6 +68,18 @@ class BaseField
     public function get_name()
     {
         return $this->name;
+    }
+    
+    /**
+     * @param $label
+     *
+     * @return string
+     */
+    protected function with_label($label)
+    {
+        $this->set_label($label);
+
+        return $this;
     }
 
     /**
@@ -98,6 +116,24 @@ class BaseField
     public function get_key()
     {
         return $this->key;
+    }
+
+    /**
+     * @param $args
+     *
+     * @return string
+     */
+    private function add_args($args = [])
+    {
+        $this->args = array_merge($this->args, $args);
+    }
+
+    /**
+     * @return string
+     */
+    public function get_args()
+    {
+        return $this->args;
     }
 
     /**

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -3,9 +3,14 @@
 namespace DigitOne\Acf;
 
 use DigitOne\Acf\Helper\AcfWpmlHelper;
+use DigitOne\Acf\OptionTraits\Instructions;
+use DigitOne\Acf\OptionTraits\Required;
 
 class BaseField
 {
+    use Instructions;
+    use Required;
+
     protected $prefix;
     protected $name;
     protected $label;
@@ -39,7 +44,7 @@ class BaseField
      *
      * @return array
      */
-    public function build(array $parameter = [])
+    public function build(array $parameter = [])    
     {
         $defaults = [
             'key'   => $this->get_key(),
@@ -116,36 +121,6 @@ class BaseField
     public function get_name()
     {
         return $this->name;
-    }
-
-    /**
-     * @param $instructions
-     *
-     * @return string
-     */
-    public function instructions($instructions)
-    {
-        $this->set_instructions($instructions);
-
-        return $this;
-    }
-
-    /**
-     * @param $instructions
-     *
-     * @return string
-     */
-    public function set_instructions($instructions)
-    {
-        $this->args['instructions'] = $instructions;
-    }
-
-    /**
-     * @return string
-     */
-    public function get_instructions()
-    {
-        return $this->args['instructions'];
     }
     
     /**

--- a/src/BaseField.php
+++ b/src/BaseField.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf;
+namespace DigitOne\Acf;
 
-use Towa\Acf\Helper\AcfWpmlHelper;
+use DigitOne\Acf\Helper\AcfWpmlHelper;
 
 class BaseField
 {

--- a/src/BaseParentField.php
+++ b/src/BaseParentField.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Towa\Acf;
+
+use Towa\Acf\BaseField;
+
+class BaseParentField extends BaseField
+{
+    protected $sub_fields = [];
+
+    /**
+     * @param array[BaseField] sub_fields of this field
+     * 
+     * @return BaseParentField the updated instance
+     */
+    public function with_sub_fields($sub_fields = [])
+    {
+        $this->set_sub_fields($sub_fields);
+
+        return $this;
+    }
+
+    /**
+     * @param array[BaseField] sub_fields of this field
+     */
+    public function set_sub_fields($sub_fields = [])
+    {
+        $this->sub_fields = collect($sub_fields)
+            ->mapWithKeys(function ($field, $key) {
+              if (!is_subclass_of($field, BaseField::class)) {
+                  error_log("WARN: set_sub_fields called with an Array that contains something that is not of type BaseField: " . print_r($field, true));
+                  return false;
+              }
+
+              return [ $field->get_name() => $field ];
+            })->filter()->toArray();
+    }
+
+    public function get_sub_fields()
+    {
+        return $this->sub_fields;
+    }
+
+    /**
+     * Builds the array for ACF registration. 
+     *
+     * @param array  $parameter to be added to the registration (deprecated)
+     *
+     * @return array for ACF registration
+     */
+    public function build($parameter = [])
+    {
+        if (!$this->sub_fields) {
+            return parent::build($parameter);
+        }
+
+        return parent::build(array_merge($parameter, [
+            'sub_fields' => $this->build_sub_fields()
+        ]));
+    }
+
+    /**
+     * Recursively builds the sub_fields of this field.
+     * 
+     * @return array of acf registration data
+     */
+    private function build_sub_fields()
+    {
+        if (!$this->sub_fields) {
+            return [];
+        }
+
+        return collect($this->sub_fields)
+            ->map(function($sub_field) {
+                return $sub_field->build();
+            })->toArray();
+    }
+
+    /**
+     * Recursively calls the transform methods of the sub_fields
+     * with their data.
+     * 
+     * @param data that is returned by ACF get_field() for this field
+     * 
+     * @return array of recursively transformed data
+     */
+    public function transform($data)
+    {
+        return collect($data)
+            ->mapWithKeys(function($value, $key) {
+                if (!array_key_exists($key, $this->sub_fields)) {
+                    return [$key => $value];
+                }
+
+                $sub_field = $this->sub_fields[$key];
+                return [ $key => $sub_field->transform($value)];
+            })->toArray();
+    }
+}

--- a/src/BaseParentField.php
+++ b/src/BaseParentField.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf;
+namespace DigitOne\Acf;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class BaseParentField extends BaseField
 {

--- a/src/BaseParentField.php
+++ b/src/BaseParentField.php
@@ -13,7 +13,7 @@ class BaseParentField extends BaseField
      * 
      * @return BaseParentField the updated instance
      */
-    public function with_sub_fields($sub_fields = [])
+    public function sub_fields($sub_fields = [])
     {
         $this->set_sub_fields($sub_fields);
 
@@ -31,6 +31,8 @@ class BaseParentField extends BaseField
                   error_log("WARN: set_sub_fields called with an Array that contains something that is not of type BaseField: " . print_r($field, true));
                   return false;
               }
+
+              $field->set_prefix($this->get_key());
 
               return [ $field->get_name() => $field ];
             })->filter()->toArray();

--- a/src/BaseSection.php
+++ b/src/BaseSection.php
@@ -2,6 +2,9 @@
 
 namespace Towa\Acf;
 
+/**
+ * @deprecated (use Fields\Layout instead)
+ */
 abstract class BaseSection
 {
     private $key;

--- a/src/BaseSection.php
+++ b/src/BaseSection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Towa\Acf;
+namespace DigitOne\Acf;
 
 /**
  * @deprecated (use Fields\Layout instead)

--- a/src/Extensions/AcfFonticonpicker/AcfIconfield.php
+++ b/src/Extensions/AcfFonticonpicker/AcfIconfield.php
@@ -10,7 +10,7 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
-namespace Towa\Acf\Extensions\AcfFonticonpicker;
+namespace DigitOne\Acf\Extensions\AcfFonticonpicker;
 
 /**
  * Class AcfIconfield

--- a/src/Extensions/AcfGravityForm/AcfGravityForm.php
+++ b/src/Extensions/AcfGravityForm/AcfGravityForm.php
@@ -11,7 +11,7 @@ License URI: http://opensource.org/licenses/MIT
 */
 
 // $version = 5 and can be ignored until ACF6 exists
-namespace Towa\Acf\Extensions\AcfGravityForm;
+namespace DigitOne\Acf\Extensions\AcfGravityForm;
 
 class AcfGravityForm
 {

--- a/src/FieldGroup.php
+++ b/src/FieldGroup.php
@@ -1,7 +1,15 @@
 <?php
 
 namespace DigitOne\Acf;
+use DigitOne\Acf\Fields\Group;
 
+/**
+ * The ACF FieldGroup that is used to register and display fields depending on different custom rules.
+ * 
+ * This class registeres all its ACF fields as sub fields of an internal ACF Group (wrapper_group) that is named
+ * same as the FieldGroup itself. Data of the fields of a FieldGroup with name 'some_field_group' can be 
+ * accessed by calling get_field('some_field_group') - under the hood you are fetching the data from the wrapper group.
+ */
 class FieldGroup
 {
     private $data = [
@@ -11,10 +19,44 @@ class FieldGroup
         'location' => [],
     ];
 
-    public function __construct($key, $title)
+    private $acf_data = [];
+
+    /**
+     * Fields of a FieldGroup are registered without a wrapper per default.
+     * This wrapper group ensures that get_field($name) returns the data of this FieldGroup 
+     * (the data of its children)
+     */
+    private $wrapper_group;
+
+
+    public function __construct($name, $label = '')
     {
-        $this->data['title'] = $title;
-        $this->data['key']   = "group_{$key}";
+        $this->data['title'] = $label;
+        $this->data['key']   = "group_{$name}";
+        $this->wrapper_group = new Group($this->data['key'], $name, label: '');
+    }
+
+    /**
+     * Fetches the data of the fields of this FieldGroup
+     * 
+     * @param post_id (optional) the post id to pass onto ACF get_field()
+     * @return FieldGroup the updated instance
+     */
+    public function fetch($post_id = false)
+    {
+        $this->acf_data = get_field($this->wrapper_group->get_name(), $post_id);
+
+        return $this;
+    }
+
+    /**
+     * Transforms the previously fetched ACF data.
+     * 
+     * @return array the transformed data
+     */
+    public function transform()
+    {
+        return $this->wrapper_group->transform($this->acf_data);
     }
 
     public function for_cpt($cpt = 'post')
@@ -71,13 +113,24 @@ class FieldGroup
         return $this;
     }
 
+    /**
+     * @deprecated
+     */
     public function for_location($rule)
+    {
+        return $this->location($rule);
+    }
+
+    public function location($rule)
     {
         $this->data[ 'location' ][] = $rule;
 
         return $this;
     }
 
+    /**
+     * @deprecated
+     */
     public function set_fields($fields)
     {
         $this->data['fields'] = $fields;
@@ -85,9 +138,31 @@ class FieldGroup
         return $this;
     }
 
+    /**
+     * Sets the sub_fields of the wrapper_group
+     * (The wrapper_group is the one and only field of this FieldGroup)
+     * 
+     * @param array[BaseField] sub_fields
+     * @return FieldGroup the updated instance
+     */
+    public function sub_fields(array $sub_fields)
+    {
+        $this->wrapper_group->sub_fields($sub_fields);
+        $this->data['fields'] = [ $this->wrapper_group->build() ];
+
+        return $this;
+    }
+
     public function set_setting($setting, $data)
     {
         $this->data[ $setting ] = $data;
+
+        return $this;
+    }
+
+    public function settings(array $settings)
+    {
+        $this->data = array_merge($this->data, $settings);
 
         return $this;
     }

--- a/src/FieldGroup.php
+++ b/src/FieldGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Towa\Acf;
+namespace DigitOne\Acf;
 
 class FieldGroup
 {

--- a/src/Fields/Buttongroup.php
+++ b/src/Fields/Buttongroup.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Buttongroup extends BaseField
 {

--- a/src/Fields/Checkbox.php
+++ b/src/Fields/Checkbox.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 /**
  * Checkbox Field for ACF

--- a/src/Fields/CloneField.php
+++ b/src/Fields/CloneField.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class CloneField extends BaseField
 {

--- a/src/Fields/ColorPicker.php
+++ b/src/Fields/ColorPicker.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class ColorPicker extends BaseField
 {

--- a/src/Fields/DateTimePicker.php
+++ b/src/Fields/DateTimePicker.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class DateTimePicker extends BaseField
 {

--- a/src/Fields/Datepicker.php
+++ b/src/Fields/Datepicker.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Datepicker extends BaseField
 {

--- a/src/Fields/Email.php
+++ b/src/Fields/Email.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Email extends BaseField
 {

--- a/src/Fields/File.php
+++ b/src/Fields/File.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class File extends BaseField
 {

--- a/src/Fields/FlexibleContent.php
+++ b/src/Fields/FlexibleContent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 /**
  * Flexible Content Field for ACF

--- a/src/Fields/Gallery.php
+++ b/src/Fields/Gallery.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Gallery extends BaseField
 {

--- a/src/Fields/GoogleMap.php
+++ b/src/Fields/GoogleMap.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class GoogleMap extends BaseField
 {

--- a/src/Fields/GravityForm.php
+++ b/src/Fields/GravityForm.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class GravityForm extends BaseField
 {

--- a/src/Fields/Group.php
+++ b/src/Fields/Group.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseParentField;
+use DigitOne\Acf\BaseParentField;
 
 class Group extends BaseParentField
 {

--- a/src/Fields/Group.php
+++ b/src/Fields/Group.php
@@ -2,19 +2,12 @@
 
 namespace Towa\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use Towa\Acf\BaseParentField;
 
-class Group extends BaseField
+class Group extends BaseParentField
 {
     protected $prefix;
     protected $name = 'group';
     protected $label = 'Group';
     protected $type = 'group';
-
-    public function build(array $parameter = [])
-    {
-        $default = [ 'sub_fields' => [] ];
-
-        return parent::build(array_merge($default, $parameter));
-    }
 }

--- a/src/Fields/Icon.php
+++ b/src/Fields/Icon.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Icon extends BaseField
 {

--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Image extends BaseField
 {

--- a/src/Fields/Layout.php
+++ b/src/Fields/Layout.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseParentField;
+use DigitOne\Acf\BaseParentField;
 
 class Layout extends BaseParentField
 {

--- a/src/Fields/Layout.php
+++ b/src/Fields/Layout.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Towa\Acf\Fields;
+
+use Towa\Acf\BaseParentField;
+
+class Layout extends BaseParentField
+{
+    protected $prefix;
+    protected $name = 'layout';
+    protected $label = 'Layout';
+    protected $type = 'layout';
+    protected $args = [
+        'display' => 'block',
+    ];
+}

--- a/src/Fields/Link.php
+++ b/src/Fields/Link.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Link extends BaseField
 {

--- a/src/Fields/Message.php
+++ b/src/Fields/Message.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Message extends BaseField
 {

--- a/src/Fields/Number.php
+++ b/src/Fields/Number.php
@@ -1,7 +1,7 @@
 <?php
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Number extends BaseField
 {

--- a/src/Fields/Oembed.php
+++ b/src/Fields/Oembed.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Oembed extends BaseField
 {

--- a/src/Fields/PageLink.php
+++ b/src/Fields/PageLink.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class PageLink extends BaseField
 {

--- a/src/Fields/PostObject.php
+++ b/src/Fields/PostObject.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class PostObject extends BaseField
 {

--- a/src/Fields/Relation.php
+++ b/src/Fields/Relation.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Relation extends BaseField
 {

--- a/src/Fields/Repeater.php
+++ b/src/Fields/Repeater.php
@@ -2,41 +2,15 @@
 
 namespace Towa\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use Towa\Acf\BaseParentField;
 
-class Repeater extends BaseField
+class Repeater extends BaseParentField
 {
     protected $prefix;
     protected $name = 'repeater';
     protected $type = 'repeater';
     protected $label = 'Wiederholung';
-
-    /**
-     * @param string $name_key
-     * @param string $label
-     * @param array  $parameter
-     *
-     * @return array
-     */
-    public function build(array $parameter = [])
-    {
-
-//		$this->set_name( $name_key );
-
-        $add_to_defaults = [
-            'button_label' => 'hinzufügen',
-            'sub_fields'   => [],
-        ];
-
-        //		$add_to_defaults = array_merge( (array) $add_to_defaults, (array) $parameter );
-
-        //		foreach ( $add_to_defaults['sub_fields'] as &$value ) {
-
-        //TODO change key ?
-        //			$value['key'] = $value['key'] . '_' . $this->get_name();
-        //		}
-
-        //		return parent::build( $add_to_defaults );
-        return parent::build(array_merge((array) $add_to_defaults, (array) $parameter));
-    }
+    protected $args = [
+        'button_label' => 'hinzufügen',
+    ];
 }

--- a/src/Fields/Repeater.php
+++ b/src/Fields/Repeater.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseParentField;
+use DigitOne\Acf\BaseParentField;
 
 class Repeater extends BaseParentField
 {

--- a/src/Fields/Restricted.php
+++ b/src/Fields/Restricted.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Restricted extends BaseField
 {

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Select extends BaseField
 {

--- a/src/Fields/Tab.php
+++ b/src/Fields/Tab.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Tab extends BaseField
 {

--- a/src/Fields/Taxonomy.php
+++ b/src/Fields/Taxonomy.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Taxonomy extends BaseField
 {

--- a/src/Fields/Text.php
+++ b/src/Fields/Text.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Text extends BaseField
 {

--- a/src/Fields/Textarea.php
+++ b/src/Fields/Textarea.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Textarea extends BaseField
 {

--- a/src/Fields/TimePicker.php
+++ b/src/Fields/TimePicker.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class TimePicker extends BaseField
 {

--- a/src/Fields/TrueFalse.php
+++ b/src/Fields/TrueFalse.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class TrueFalse extends BaseField
 {

--- a/src/Fields/Url.php
+++ b/src/Fields/Url.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Url extends BaseField
 {

--- a/src/Fields/Wysiwyg.php
+++ b/src/Fields/Wysiwyg.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Towa\Acf\Fields;
+namespace DigitOne\Acf\Fields;
 
-use Towa\Acf\BaseField;
+use DigitOne\Acf\BaseField;
 
 class Wysiwyg extends BaseField
 {

--- a/src/Helper/AcfWpmlHelper.php
+++ b/src/Helper/AcfWpmlHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Towa\Acf\Helper;
+namespace DigitOne\Acf\Helper;
 
 abstract class AcfWpmlHelper
 {

--- a/src/Modules/PageOrUrl.php
+++ b/src/Modules/PageOrUrl.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Towa\Acf\Modules;
+namespace DigitOne\Acf\Modules;
 
-use Towa\Acf\BaseField;
-use Towa\Acf\Fields\Url;
-use Towa\Acf\Fields\Select;
-use Towa\Acf\Fields\PageLink;
+use DigitOne\Acf\BaseField;
+use DigitOne\Acf\Fields\Url;
+use DigitOne\Acf\Fields\Select;
+use DigitOne\Acf\Fields\PageLink;
 
 class PageOrUrl extends BaseField
 {

--- a/src/OptionTraits/ConditionalLogic.php
+++ b/src/OptionTraits/ConditionalLogic.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DigitOne\Acf\OptionTraits;
+
+
+trait ConditionalLogic {
+    /**
+     * @param $conditional_logic
+     *
+     * @return the updated instance
+     */
+    public function conditional_logic($conditional_logic)
+    {
+        $this->set_conditional_logic($conditional_logic);
+
+        return $this;
+    }
+
+    /**
+     * @param $conditional_logic
+     */
+    public function set_conditional_logic($conditional_logic)
+    {
+        $this->args['conditional_logic'] = $conditional_logic;
+    }
+
+    /**
+     * @return String
+     */
+    public function get_conditional_logic()
+    {
+        return $this->args['conditional_logic'];
+    }
+}

--- a/src/OptionTraits/DefaultValue.php
+++ b/src/OptionTraits/DefaultValue.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DigitOne\Acf\OptionTraits;
+
+
+trait DefaultValue {
+    /**
+     * @param $default_value
+     *
+     * @return the updated instance
+     */
+    public function default_value($default_value)
+    {
+        $this->set_default_value($default_value);
+
+        return $this;
+    }
+
+    /**
+     * @param $default_value
+     */
+    public function set_default_value($default_value)
+    {
+        $this->args['default_value'] = $default_value;
+    }
+
+    /**
+     * @return String
+     */
+    public function get_default_value()
+    {
+        return $this->args['default_value'];
+    }
+}

--- a/src/OptionTraits/Instructions.php
+++ b/src/OptionTraits/Instructions.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DigitOne\Acf\OptionTraits;
+
+
+trait Instructions {
+    /**
+     * @param $instructions
+     *
+     * @return the updated instance
+     */
+    public function instructions($instructions)
+    {
+        $this->set_instructions($instructions);
+
+        return $this;
+    }
+
+    /**
+     * @param $instructions
+     */
+    public function set_instructions($instructions)
+    {
+        $this->args['instructions'] = $instructions;
+    }
+
+    /**
+     * @return String
+     */
+    public function get_instructions()
+    {
+        return $this->args['instructions'];
+    }
+}

--- a/src/OptionTraits/Required.php
+++ b/src/OptionTraits/Required.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DigitOne\Acf\OptionTraits;
+
+
+trait Required {
+    /**
+     * @return the updated instance
+     */
+    public function required()
+    {
+        $this->set_required(true);
+
+        return $this;
+    }
+
+    /**
+     * @param $required
+     */
+    public function set_required($required)
+    {
+        $this->args['required'] = $required;
+    }
+
+    /**
+     * @return Boolean
+     */
+    public function is_required()
+    {
+        return $this->args['required'];
+    }
+}

--- a/src/OptionTraits/Wrapper.php
+++ b/src/OptionTraits/Wrapper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DigitOne\Acf\OptionTraits;
+
+
+trait Wrapper {
+    /**
+     * @param $wrapper
+     *
+     * @return the updated instance
+     */
+    public function wrapper($wrapper)
+    {
+        $this->set_wrapper($wrapper);
+
+        return $this;
+    }
+
+    /**
+     * @param $wrapper
+     */
+    public function set_wrapper($wrapper)
+    {
+        $this->args['wrapper'] = $wrapper;
+    }
+
+    /**
+     * @return String
+     */
+    public function get_wrapper()
+    {
+        return $this->args['wrapper'];
+    }
+}


### PR DESCRIPTION
### TLDR

- added new ACF field `Layout`
- introduce new `BaseParentField` that serves as super class for `Group`, `Repeater` and `Layout` (e.g. for any ACF field that has sub_fields)
- changed package details and namespace
- introduce new constructor parameter for `BaseField` to be able to pass in `args` (`BaseField::build($parameters)` is deprecated in favour of `BaseField::build()` and passing the parameters via the constructor)
- refactor `FieldGroup` such that there is a wrapper Group used internally (to utilise its build and transform)

### Usage of BaseParentField
The idea is that a parent field (like a Group or Repeater) manages its sub_fields as a list of BaseField (or BaseParentField) instances. With that it's possible that a BaseParentField::build() and a BaseParentField::transform() can call its sub_fields build and transform methods. We can name this recursive build or recursive transform as a sub_field can be an instance of BaseParentField again. The recursion ends on BaseField instances.

The recursive transform has the main benefit that one is able to introduce a new (project specific) custom ACF field (by extending the Group for example) that has its own specific transform method and use it throughout a project like one would use any other ACF field from this package. You can nest custom fields and always be sure that any field is transformed properly.
Another example could be that one extends the PostObject field and implements a new return_type option for it. Inside the CustomPostObject::transform() one can access the args (e.g. the specified return_type option) and do some logic based on this option (for example fetching some post related data). CustomPostObject can then be used anywhere like any other ACF field and is automatically transformed properly by its parent.

### Improved FieldGroup
The `FieldGroup` uses an ACF field Group internally to register all its fields as sub fields of that group. 
That original implementation has some flaws:
- ACF registers fields of a field group without a wrapper -> For example if you register a 'Hero' field group with fields named 'title' and 'image' you would have to fetch this data via get_field('title') and get_field('image'). This can get confusing if you register different groups on the same post type.
- The new recursive build and transform approach does not work with the fields of a FieldGroup -> this needs to be implemented somehow

The new implementation has some main benefits:
- All fields of a FieldGroup are registered as sub fields of a wrapper group which is itself the only field of the FieldGroup. This group is named same as the FieldGroup. The data of the FieldGroup can now be fetched by get_field().
- build and transform of the fields are handled by the wrapper group (to meet the new recursive build and transform requirements)
